### PR TITLE
feat: add localization support for fonts and UI text

### DIFF
--- a/PeaversDynamicStats.toc
+++ b/PeaversDynamicStats.toc
@@ -13,6 +13,9 @@
 # Main
 src\Main.lua
 
+# Localization (load early)
+src\Localization.lua
+
 # UI first (since Config depends on it)
 src\UI\UI.lua
 

--- a/src/Localization.lua
+++ b/src/Localization.lua
@@ -1,0 +1,424 @@
+local _, PDS = ...
+
+-- Initialize Localization namespace
+PDS.L = {}
+local L = PDS.L
+
+-- Get the client's locale
+local locale = GetLocale()
+
+-- Default locale (English)
+local defaultLocale = "enUS"
+
+-- Localization tables
+local Locales = {}
+
+-- English (Default)
+Locales["enUS"] = {
+    -- Stat Names
+    ["STAT_STRENGTH"] = "Strength",
+    ["STAT_AGILITY"] = "Agility",
+    ["STAT_INTELLECT"] = "Intellect",
+    ["STAT_STAMINA"] = "Stamina",
+    ["STAT_HASTE"] = "Haste",
+    ["STAT_CRIT"] = "Critical Strike",
+    ["STAT_MASTERY"] = "Mastery",
+    ["STAT_VERSATILITY"] = "Versatility",
+    ["STAT_VERSATILITY_DAMAGE"] = "Versatility (Damage)",
+    ["STAT_VERSATILITY_DEFENSE"] = "Versatility (Defense)",
+    ["STAT_SPEED"] = "Speed",
+    ["STAT_LEECH"] = "Leech",
+    ["STAT_AVOIDANCE"] = "Avoidance",
+    ["STAT_DEFENSE"] = "Defense",
+    ["STAT_DODGE"] = "Dodge",
+    ["STAT_PARRY"] = "Parry",
+    ["STAT_BLOCK"] = "Block",
+    ["STAT_ARMOR_PENETRATION"] = "Armor Penetration",
+    
+    -- Commands
+    ["CMD_TOGGLE"] = "Toggle stats display",
+    ["CMD_CONFIG"] = "Open configuration panel",
+    ["CMD_HELP"] = "Show available commands",
+    
+    -- Config UI - Section Headers
+    ["CONFIG_DISPLAY_SETTINGS"] = "Display Settings",
+    ["CONFIG_STAT_OPTIONS"] = "Stat Options",
+    ["CONFIG_BAR_APPEARANCE"] = "Bar Appearance",
+    ["CONFIG_SPEC_SETTINGS"] = "Specialization Settings",
+    ["CONFIG_TEXT_SETTINGS"] = "Text Settings",
+    
+    -- Config UI - Display Settings
+    ["CONFIG_FRAME_DIMENSIONS"] = "Frame Dimensions:",
+    ["CONFIG_FRAME_WIDTH"] = "Frame Width",
+    ["CONFIG_BG_OPACITY"] = "Background Opacity",
+    ["CONFIG_VISIBILITY_OPTIONS"] = "Visibility Options:",
+    ["CONFIG_SHOW_TITLE_BAR"] = "Show Title Bar",
+    ["CONFIG_LOCK_POSITION"] = "Lock Frame Position",
+    ["CONFIG_HIDE_OUT_OF_COMBAT"] = "Hide When Out of Combat",
+    ["CONFIG_DISPLAY_MODE"] = "Display Mode",
+    ["CONFIG_DISPLAY_MODE_ALWAYS"] = "Always Show",
+    ["CONFIG_DISPLAY_MODE_PARTY"] = "Show in Party Only",
+    ["CONFIG_DISPLAY_MODE_RAID"] = "Show in Raid Only",
+    
+    -- Config UI - Stat Options
+    ["CONFIG_PRIMARY_STATS"] = "Primary Stats",
+    ["CONFIG_PRIMARY_STATS_DESC"] = "Primary stats are calculated as percentages, starting at 100% (base value). Buffs, talents, and equipment can increase these values beyond 100%. Higher percentages represent better performance.",
+    ["CONFIG_SECONDARY_STATS"] = "Secondary Stats",
+    ["CONFIG_SECONDARY_STATS_DESC"] = "Secondary stats enhance your character's performance: Crit, Haste, Mastery, Versatility, etc.",
+    ["CONFIG_SHOW_STAT"] = "Show %s",
+    ["CONFIG_BAR_COLOR"] = "Bar Color:",
+    
+    -- Config UI - Bar Appearance
+    ["CONFIG_BAR_DIMENSIONS"] = "Bar Dimensions:",
+    ["CONFIG_BAR_HEIGHT"] = "Bar Height",
+    ["CONFIG_BAR_SPACING"] = "Bar Spacing",
+    ["CONFIG_BAR_BG_OPACITY"] = "Bar Background Opacity",
+    ["CONFIG_BAR_STYLE"] = "Bar Style:",
+    ["CONFIG_BAR_TEXTURE"] = "Bar Texture",
+    ["CONFIG_ADDITIONAL_BAR_OPTIONS"] = "Additional Bar Options:",
+    ["CONFIG_SHOW_STAT_CHANGES"] = "Show Stat Value Changes",
+    ["CONFIG_SHOW_RATINGS"] = "Show Rating Values",
+    ["CONFIG_SHOW_OVERFLOW_BARS"] = "Show Overflow Bars",
+    ["CONFIG_ENABLE_TALENT_ADJUSTMENTS"] = "Enable Talent Adjustments (Rogue: Thief's Versatility)",
+    
+    -- Config UI - Spec Settings
+    ["CONFIG_SPEC_DESC"] = "Control whether your addon settings should be shared between all specializations or customized per spec.",
+    ["CONFIG_USE_SHARED_SPEC"] = "Use same settings for all specializations",
+    ["CONFIG_SPEC_INFO"] = "When enabled, your stat visibility, bar appearance, and other settings will be the same for all specs. When disabled, each spec can have unique settings.",
+    ["CONFIG_SPEC_SHARED_MSG"] = "Settings will now be shared across all specializations",
+    ["CONFIG_SPEC_SEPARATE_MSG"] = "Each specialization will now use its own settings",
+    
+    -- Config UI - Text Settings
+    ["CONFIG_FONT_SELECTION"] = "Font Selection:",
+    ["CONFIG_FONT"] = "Font",
+    ["CONFIG_FONT_SIZE"] = "Font Size",
+    ["CONFIG_FONT_STYLE"] = "Font Style:",
+    ["CONFIG_FONT_OUTLINE"] = "Outlined Font",
+    ["CONFIG_FONT_SHADOW"] = "Font Shadow",
+    
+    -- Messages
+    ["MSG_ADDON_LOADED"] = "PeaversDynamicStats loaded. Type /pds for commands.",
+    ["MSG_SHOWN"] = "PeaversDynamicStats shown.",
+    ["MSG_HIDDEN"] = "PeaversDynamicStats hidden.",
+    
+    -- Misc
+    ["NEW_BADGE"] = "NEW!",
+}
+
+-- Simplified Chinese (简体中文)
+Locales["zhCN"] = {
+    -- Stat Names
+    ["STAT_STRENGTH"] = "力量",
+    ["STAT_AGILITY"] = "敏捷",
+    ["STAT_INTELLECT"] = "智力",
+    ["STAT_STAMINA"] = "耐力",
+    ["STAT_HASTE"] = "急速",
+    ["STAT_CRIT"] = "暴击",
+    ["STAT_MASTERY"] = "精通",
+    ["STAT_VERSATILITY"] = "全能",
+    ["STAT_VERSATILITY_DAMAGE"] = "全能（伤害）",
+    ["STAT_VERSATILITY_DEFENSE"] = "全能（防御）",
+    ["STAT_SPEED"] = "速度",
+    ["STAT_LEECH"] = "吸血",
+    ["STAT_AVOIDANCE"] = "闪避",
+    ["STAT_DEFENSE"] = "防御",
+    ["STAT_DODGE"] = "躲闪",
+    ["STAT_PARRY"] = "招架",
+    ["STAT_BLOCK"] = "格挡",
+    ["STAT_ARMOR_PENETRATION"] = "护甲穿透",
+    
+    -- Commands
+    ["CMD_TOGGLE"] = "切换属性显示",
+    ["CMD_CONFIG"] = "打开配置面板",
+    ["CMD_HELP"] = "显示可用命令",
+    
+    -- Config UI - Section Headers
+    ["CONFIG_DISPLAY_SETTINGS"] = "显示设置",
+    ["CONFIG_STAT_OPTIONS"] = "属性选项",
+    ["CONFIG_BAR_APPEARANCE"] = "进度条外观",
+    ["CONFIG_SPEC_SETTINGS"] = "专精设置",
+    ["CONFIG_TEXT_SETTINGS"] = "文字设置",
+    
+    -- Config UI - Display Settings
+    ["CONFIG_FRAME_DIMENSIONS"] = "框架尺寸：",
+    ["CONFIG_FRAME_WIDTH"] = "框架宽度",
+    ["CONFIG_BG_OPACITY"] = "背景透明度",
+    ["CONFIG_VISIBILITY_OPTIONS"] = "可见性选项：",
+    ["CONFIG_SHOW_TITLE_BAR"] = "显示标题栏",
+    ["CONFIG_LOCK_POSITION"] = "锁定框架位置",
+    ["CONFIG_HIDE_OUT_OF_COMBAT"] = "脱离战斗时隐藏",
+    ["CONFIG_DISPLAY_MODE"] = "显示模式",
+    ["CONFIG_DISPLAY_MODE_ALWAYS"] = "始终显示",
+    ["CONFIG_DISPLAY_MODE_PARTY"] = "仅在小队中显示",
+    ["CONFIG_DISPLAY_MODE_RAID"] = "仅在团队中显示",
+    
+    -- Config UI - Stat Options
+    ["CONFIG_PRIMARY_STATS"] = "主要属性",
+    ["CONFIG_PRIMARY_STATS_DESC"] = "主要属性以百分比计算，从100%（基础值）开始。增益、天赋和装备可以将这些值提高到100%以上。百分比越高代表性能越好。",
+    ["CONFIG_SECONDARY_STATS"] = "次要属性",
+    ["CONFIG_SECONDARY_STATS_DESC"] = "次要属性增强你的角色性能：暴击、急速、精通、全能等。",
+    ["CONFIG_SHOW_STAT"] = "显示%s",
+    ["CONFIG_BAR_COLOR"] = "进度条颜色：",
+    
+    -- Config UI - Bar Appearance
+    ["CONFIG_BAR_DIMENSIONS"] = "进度条尺寸：",
+    ["CONFIG_BAR_HEIGHT"] = "进度条高度",
+    ["CONFIG_BAR_SPACING"] = "进度条间距",
+    ["CONFIG_BAR_BG_OPACITY"] = "进度条背景透明度",
+    ["CONFIG_BAR_STYLE"] = "进度条样式：",
+    ["CONFIG_BAR_TEXTURE"] = "进度条材质",
+    ["CONFIG_ADDITIONAL_BAR_OPTIONS"] = "其他进度条选项：",
+    ["CONFIG_SHOW_STAT_CHANGES"] = "显示属性值变化",
+    ["CONFIG_SHOW_RATINGS"] = "显示等级值",
+    ["CONFIG_SHOW_OVERFLOW_BARS"] = "显示溢出条",
+    ["CONFIG_ENABLE_TALENT_ADJUSTMENTS"] = "启用天赋调整（盗贼：盗贼的全能）",
+    
+    -- Config UI - Spec Settings
+    ["CONFIG_SPEC_DESC"] = "控制插件设置是在所有专精之间共享还是为每个专精单独定制。",
+    ["CONFIG_USE_SHARED_SPEC"] = "所有专精使用相同设置",
+    ["CONFIG_SPEC_INFO"] = "启用时，你的属性可见性、进度条外观和其他设置将在所有专精中保持一致。禁用时，每个专精可以有独特的设置。",
+    ["CONFIG_SPEC_SHARED_MSG"] = "设置现在将在所有专精之间共享",
+    ["CONFIG_SPEC_SEPARATE_MSG"] = "每个专精现在将使用自己的设置",
+    
+    -- Config UI - Text Settings
+    ["CONFIG_FONT_SELECTION"] = "字体选择：",
+    ["CONFIG_FONT"] = "字体",
+    ["CONFIG_FONT_SIZE"] = "字体大小",
+    ["CONFIG_FONT_STYLE"] = "字体样式：",
+    ["CONFIG_FONT_OUTLINE"] = "字体描边",
+    ["CONFIG_FONT_SHADOW"] = "字体阴影",
+    
+    -- Messages
+    ["MSG_ADDON_LOADED"] = "PeaversDynamicStats 已加载。输入 /pds 查看命令。",
+    ["MSG_SHOWN"] = "PeaversDynamicStats 已显示。",
+    ["MSG_HIDDEN"] = "PeaversDynamicStats 已隐藏。",
+    
+    -- Misc
+    ["NEW_BADGE"] = "新功能！",
+}
+
+-- Traditional Chinese (繁體中文)
+Locales["zhTW"] = {
+    -- Stat Names
+    ["STAT_STRENGTH"] = "力量",
+    ["STAT_AGILITY"] = "敏捷",
+    ["STAT_INTELLECT"] = "智力",
+    ["STAT_STAMINA"] = "耐力",
+    ["STAT_HASTE"] = "加速",
+    ["STAT_CRIT"] = "致命一擊",
+    ["STAT_MASTERY"] = "精通",
+    ["STAT_VERSATILITY"] = "臨機應變",
+    ["STAT_VERSATILITY_DAMAGE"] = "臨機應變（傷害）",
+    ["STAT_VERSATILITY_DEFENSE"] = "臨機應變（防禦）",
+    ["STAT_SPEED"] = "速度",
+    ["STAT_LEECH"] = "汲取",
+    ["STAT_AVOIDANCE"] = "迴避",
+    ["STAT_DEFENSE"] = "防禦",
+    ["STAT_DODGE"] = "閃躲",
+    ["STAT_PARRY"] = "招架",
+    ["STAT_BLOCK"] = "格擋",
+    ["STAT_ARMOR_PENETRATION"] = "護甲穿透",
+    
+    -- Commands
+    ["CMD_TOGGLE"] = "切換屬性顯示",
+    ["CMD_CONFIG"] = "開啟設定面板",
+    ["CMD_HELP"] = "顯示可用指令",
+    
+    -- Config UI - Section Headers
+    ["CONFIG_DISPLAY_SETTINGS"] = "顯示設定",
+    ["CONFIG_STAT_OPTIONS"] = "屬性選項",
+    ["CONFIG_BAR_APPEARANCE"] = "進度條外觀",
+    ["CONFIG_SPEC_SETTINGS"] = "專精設定",
+    ["CONFIG_TEXT_SETTINGS"] = "文字設定",
+    
+    -- Config UI - Display Settings
+    ["CONFIG_FRAME_DIMENSIONS"] = "框架尺寸：",
+    ["CONFIG_FRAME_WIDTH"] = "框架寬度",
+    ["CONFIG_BG_OPACITY"] = "背景透明度",
+    ["CONFIG_VISIBILITY_OPTIONS"] = "可見性選項：",
+    ["CONFIG_SHOW_TITLE_BAR"] = "顯示標題列",
+    ["CONFIG_LOCK_POSITION"] = "鎖定框架位置",
+    ["CONFIG_HIDE_OUT_OF_COMBAT"] = "脫離戰鬥時隱藏",
+    ["CONFIG_DISPLAY_MODE"] = "顯示模式",
+    ["CONFIG_DISPLAY_MODE_ALWAYS"] = "總是顯示",
+    ["CONFIG_DISPLAY_MODE_PARTY"] = "僅在隊伍中顯示",
+    ["CONFIG_DISPLAY_MODE_RAID"] = "僅在團隊中顯示",
+    
+    -- Config UI - Stat Options
+    ["CONFIG_PRIMARY_STATS"] = "主要屬性",
+    ["CONFIG_PRIMARY_STATS_DESC"] = "主要屬性以百分比計算，從100%（基礎值）開始。增益、天賦和裝備可以將這些值提高到100%以上。百分比越高代表性能越好。",
+    ["CONFIG_SECONDARY_STATS"] = "次要屬性",
+    ["CONFIG_SECONDARY_STATS_DESC"] = "次要屬性增強你的角色性能：致命一擊、加速、精通、臨機應變等。",
+    ["CONFIG_SHOW_STAT"] = "顯示%s",
+    ["CONFIG_BAR_COLOR"] = "進度條顏色：",
+    
+    -- Config UI - Bar Appearance
+    ["CONFIG_BAR_DIMENSIONS"] = "進度條尺寸：",
+    ["CONFIG_BAR_HEIGHT"] = "進度條高度",
+    ["CONFIG_BAR_SPACING"] = "進度條間距",
+    ["CONFIG_BAR_BG_OPACITY"] = "進度條背景透明度",
+    ["CONFIG_BAR_STYLE"] = "進度條樣式：",
+    ["CONFIG_BAR_TEXTURE"] = "進度條材質",
+    ["CONFIG_ADDITIONAL_BAR_OPTIONS"] = "其他進度條選項：",
+    ["CONFIG_SHOW_STAT_CHANGES"] = "顯示屬性值變化",
+    ["CONFIG_SHOW_RATINGS"] = "顯示等級值",
+    ["CONFIG_SHOW_OVERFLOW_BARS"] = "顯示溢出條",
+    ["CONFIG_ENABLE_TALENT_ADJUSTMENTS"] = "啟用天賦調整（盜賊：盜賊的臨機應變）",
+    
+    -- Config UI - Spec Settings
+    ["CONFIG_SPEC_DESC"] = "控制插件設定是在所有專精之間共享還是為每個專精單獨定製。",
+    ["CONFIG_USE_SHARED_SPEC"] = "所有專精使用相同設定",
+    ["CONFIG_SPEC_INFO"] = "啟用時，你的屬性可見性、進度條外觀和其他設定將在所有專精中保持一致。停用時，每個專精可以有獨特的設定。",
+    ["CONFIG_SPEC_SHARED_MSG"] = "設定現在將在所有專精之間共享",
+    ["CONFIG_SPEC_SEPARATE_MSG"] = "每個專精現在將使用自己的設定",
+    
+    -- Config UI - Text Settings
+    ["CONFIG_FONT_SELECTION"] = "字型選擇：",
+    ["CONFIG_FONT"] = "字型",
+    ["CONFIG_FONT_SIZE"] = "字型大小",
+    ["CONFIG_FONT_STYLE"] = "字型樣式：",
+    ["CONFIG_FONT_OUTLINE"] = "字型描邊",
+    ["CONFIG_FONT_SHADOW"] = "字型陰影",
+    
+    -- Messages
+    ["MSG_ADDON_LOADED"] = "PeaversDynamicStats 已載入。輸入 /pds 查看指令。",
+    ["MSG_SHOWN"] = "PeaversDynamicStats 已顯示。",
+    ["MSG_HIDDEN"] = "PeaversDynamicStats 已隱藏。",
+    
+    -- Misc
+    ["NEW_BADGE"] = "新功能！",
+}
+
+-- Korean (한국어)
+Locales["koKR"] = {
+    -- Stat Names
+    ["STAT_STRENGTH"] = "힘",
+    ["STAT_AGILITY"] = "민첩성",
+    ["STAT_INTELLECT"] = "지능",
+    ["STAT_STAMINA"] = "체력",
+    ["STAT_HASTE"] = "가속",
+    ["STAT_CRIT"] = "치명타",
+    ["STAT_MASTERY"] = "특화",
+    ["STAT_VERSATILITY"] = "유연성",
+    ["STAT_VERSATILITY_DAMAGE"] = "유연성 (공격력)",
+    ["STAT_VERSATILITY_DEFENSE"] = "유연성 (방어력)",
+    ["STAT_SPEED"] = "이동 속도",
+    ["STAT_LEECH"] = "생명력 흡수",
+    ["STAT_AVOIDANCE"] = "회피",
+    ["STAT_DEFENSE"] = "방어도",
+    ["STAT_DODGE"] = "회피율",
+    ["STAT_PARRY"] = "무기 막기",
+    ["STAT_BLOCK"] = "방패 막기",
+    ["STAT_ARMOR_PENETRATION"] = "방어구 관통력",
+    
+    -- Commands
+    ["CMD_TOGGLE"] = "능력치 표시 전환",
+    ["CMD_CONFIG"] = "설정 패널 열기",
+    ["CMD_HELP"] = "사용 가능한 명령어 표시",
+    
+    -- Config UI - Section Headers
+    ["CONFIG_DISPLAY_SETTINGS"] = "표시 설정",
+    ["CONFIG_STAT_OPTIONS"] = "능력치 옵션",
+    ["CONFIG_BAR_APPEARANCE"] = "바 외형",
+    ["CONFIG_SPEC_SETTINGS"] = "전문화 설정",
+    ["CONFIG_TEXT_SETTINGS"] = "텍스트 설정",
+    
+    -- Config UI - Display Settings
+    ["CONFIG_FRAME_DIMENSIONS"] = "프레임 크기:",
+    ["CONFIG_FRAME_WIDTH"] = "프레임 너비",
+    ["CONFIG_BG_OPACITY"] = "배경 투명도",
+    ["CONFIG_VISIBILITY_OPTIONS"] = "표시 옵션:",
+    ["CONFIG_SHOW_TITLE_BAR"] = "제목 표시줄 표시",
+    ["CONFIG_LOCK_POSITION"] = "프레임 위치 잠금",
+    ["CONFIG_HIDE_OUT_OF_COMBAT"] = "전투 중이 아닐 때 숨기기",
+    ["CONFIG_DISPLAY_MODE"] = "표시 모드",
+    ["CONFIG_DISPLAY_MODE_ALWAYS"] = "항상 표시",
+    ["CONFIG_DISPLAY_MODE_PARTY"] = "파티에서만 표시",
+    ["CONFIG_DISPLAY_MODE_RAID"] = "공격대에서만 표시",
+    
+    -- Config UI - Stat Options
+    ["CONFIG_PRIMARY_STATS"] = "주 능력치",
+    ["CONFIG_PRIMARY_STATS_DESC"] = "주 능력치는 백분율로 계산되며 100%(기본값)에서 시작합니다. 버프, 특성 및 장비로 이 값을 100% 이상으로 높일 수 있습니다. 백분율이 높을수록 성능이 향상됩니다.",
+    ["CONFIG_SECONDARY_STATS"] = "부 능력치",
+    ["CONFIG_SECONDARY_STATS_DESC"] = "부 능력치는 캐릭터의 성능을 향상시킵니다: 치명타, 가속, 특화, 유연성 등.",
+    ["CONFIG_SHOW_STAT"] = "%s 표시",
+    ["CONFIG_BAR_COLOR"] = "바 색상:",
+    
+    -- Config UI - Bar Appearance
+    ["CONFIG_BAR_DIMENSIONS"] = "바 크기:",
+    ["CONFIG_BAR_HEIGHT"] = "바 높이",
+    ["CONFIG_BAR_SPACING"] = "바 간격",
+    ["CONFIG_BAR_BG_OPACITY"] = "바 배경 투명도",
+    ["CONFIG_BAR_STYLE"] = "바 스타일:",
+    ["CONFIG_BAR_TEXTURE"] = "바 텍스처",
+    ["CONFIG_ADDITIONAL_BAR_OPTIONS"] = "추가 바 옵션:",
+    ["CONFIG_SHOW_STAT_CHANGES"] = "능력치 변화 표시",
+    ["CONFIG_SHOW_RATINGS"] = "평점 값 표시",
+    ["CONFIG_SHOW_OVERFLOW_BARS"] = "오버플로우 바 표시",
+    ["CONFIG_ENABLE_TALENT_ADJUSTMENTS"] = "특성 조정 활성화 (도적: 도적의 유연성)",
+    
+    -- Config UI - Spec Settings
+    ["CONFIG_SPEC_DESC"] = "애드온 설정을 모든 전문화 간에 공유할지 또는 각 전문화별로 사용자 지정할지 제어합니다.",
+    ["CONFIG_USE_SHARED_SPEC"] = "모든 전문화에 동일한 설정 사용",
+    ["CONFIG_SPEC_INFO"] = "활성화하면 능력치 표시, 바 외형 및 기타 설정이 모든 전문화에서 동일하게 유지됩니다. 비활성화하면 각 전문화마다 고유한 설정을 가질 수 있습니다.",
+    ["CONFIG_SPEC_SHARED_MSG"] = "이제 설정이 모든 전문화 간에 공유됩니다",
+    ["CONFIG_SPEC_SEPARATE_MSG"] = "이제 각 전문화가 자체 설정을 사용합니다",
+    
+    -- Config UI - Text Settings
+    ["CONFIG_FONT_SELECTION"] = "글꼴 선택:",
+    ["CONFIG_FONT"] = "글꼴",
+    ["CONFIG_FONT_SIZE"] = "글꼴 크기",
+    ["CONFIG_FONT_STYLE"] = "글꼴 스타일:",
+    ["CONFIG_FONT_OUTLINE"] = "글꼴 외곽선",
+    ["CONFIG_FONT_SHADOW"] = "글꼴 그림자",
+    
+    -- Messages
+    ["MSG_ADDON_LOADED"] = "PeaversDynamicStats가 로드되었습니다. /pds를 입력하여 명령어를 확인하세요.",
+    ["MSG_SHOWN"] = "PeaversDynamicStats가 표시되었습니다.",
+    ["MSG_HIDDEN"] = "PeaversDynamicStats가 숨겨졌습니다.",
+    
+    -- Misc
+    ["NEW_BADGE"] = "새로운 기능!",
+}
+
+-- Set the active locale table
+local activeLocale = Locales[locale] or Locales[defaultLocale]
+
+-- Metatable for automatic fallback to English
+setmetatable(L, {
+    __index = function(table, key)
+        -- Try to get from active locale
+        local value = activeLocale[key]
+        if value then
+            return value
+        end
+        
+        -- Fallback to English
+        value = Locales[defaultLocale][key]
+        if value then
+            return value
+        end
+        
+        -- If still not found, return the key itself
+        return key
+    end
+})
+
+-- Function to get localized text with formatting
+function PDS.L:Get(key, ...)
+    local text = L[key]
+    if ... then
+        return string.format(text, ...)
+    end
+    return text
+end
+
+-- Function to check if a locale is available
+function PDS.L:HasLocale(localeCode)
+    return Locales[localeCode] ~= nil
+end
+
+-- Function to get current locale
+function PDS.L:GetCurrentLocale()
+    return locale
+end

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -93,6 +93,11 @@ PeaversCommons.SlashCommands:Register(addonName, "pds", {
 
 -- Initialize addon using the PeaversCommons Events module
 PeaversCommons.Events:Init(addonName, function()
+    -- Initialize localization (stat names)
+    if PDS.Stats and PDS.Stats.InitializeStatNames then
+        PDS.Stats:InitializeStatNames()
+    end
+    
     -- Make sure Stats is initialized if possible
     if PDS.Stats.Initialize then
         PDS.Stats:Initialize()

--- a/src/Stats.lua
+++ b/src/Stats.lua
@@ -67,32 +67,8 @@ Stats.STAT_TYPES = {
     ARMOR_PENETRATION = "ARMOR_PENETRATION"
 }
 
--- Stat display names
-Stats.STAT_NAMES = {
-    -- Primary stats
-    [Stats.STAT_TYPES.STRENGTH] = "Strength",
-    [Stats.STAT_TYPES.AGILITY] = "Agility",
-    [Stats.STAT_TYPES.INTELLECT] = "Intellect",
-    [Stats.STAT_TYPES.STAMINA] = "Stamina",
-
-    -- Secondary stats
-    [Stats.STAT_TYPES.HASTE] = "Haste",
-    [Stats.STAT_TYPES.CRIT] = "Critical Strike",
-    [Stats.STAT_TYPES.MASTERY] = "Mastery",
-    [Stats.STAT_TYPES.VERSATILITY] = "Versatility",
-    [Stats.STAT_TYPES.VERSATILITY_DAMAGE_DONE] = "Versatility (Damage)",
-    [Stats.STAT_TYPES.VERSATILITY_DAMAGE_REDUCTION] = "Versatility (Defense)",
-    [Stats.STAT_TYPES.SPEED] = "Speed",
-    [Stats.STAT_TYPES.LEECH] = "Leech",
-    [Stats.STAT_TYPES.AVOIDANCE] = "Avoidance",
-
-    -- Combat ratings
-    [Stats.STAT_TYPES.DEFENSE] = "Defense",
-    [Stats.STAT_TYPES.DODGE] = "Dodge",
-    [Stats.STAT_TYPES.PARRY] = "Parry",
-    [Stats.STAT_TYPES.BLOCK] = "Block",
-    [Stats.STAT_TYPES.ARMOR_PENETRATION] = "Armor Penetration"
-}
+-- Stat display names (will be populated from localization)
+Stats.STAT_NAMES = {}
 
 -- Stat colors for UI purposes
 Stats.STAT_COLORS = {
@@ -678,6 +654,37 @@ function Stats:GetColor(statType)
     else
         return 0.8, 0.8, 0.8 -- Default to white/grey
     end
+end
+
+-- Initialize stat names from localization
+function Stats:InitializeStatNames()
+    if not PDS.L then return end
+    
+    Stats.STAT_NAMES = {
+        -- Primary stats
+        [Stats.STAT_TYPES.STRENGTH] = PDS.L["STAT_STRENGTH"],
+        [Stats.STAT_TYPES.AGILITY] = PDS.L["STAT_AGILITY"],
+        [Stats.STAT_TYPES.INTELLECT] = PDS.L["STAT_INTELLECT"],
+        [Stats.STAT_TYPES.STAMINA] = PDS.L["STAT_STAMINA"],
+
+        -- Secondary stats
+        [Stats.STAT_TYPES.HASTE] = PDS.L["STAT_HASTE"],
+        [Stats.STAT_TYPES.CRIT] = PDS.L["STAT_CRIT"],
+        [Stats.STAT_TYPES.MASTERY] = PDS.L["STAT_MASTERY"],
+        [Stats.STAT_TYPES.VERSATILITY] = PDS.L["STAT_VERSATILITY"],
+        [Stats.STAT_TYPES.VERSATILITY_DAMAGE_DONE] = PDS.L["STAT_VERSATILITY_DAMAGE"],
+        [Stats.STAT_TYPES.VERSATILITY_DAMAGE_REDUCTION] = PDS.L["STAT_VERSATILITY_DEFENSE"],
+        [Stats.STAT_TYPES.SPEED] = PDS.L["STAT_SPEED"],
+        [Stats.STAT_TYPES.LEECH] = PDS.L["STAT_LEECH"],
+        [Stats.STAT_TYPES.AVOIDANCE] = PDS.L["STAT_AVOIDANCE"],
+
+        -- Combat ratings
+        [Stats.STAT_TYPES.DEFENSE] = PDS.L["STAT_DEFENSE"],
+        [Stats.STAT_TYPES.DODGE] = PDS.L["STAT_DODGE"],
+        [Stats.STAT_TYPES.PARRY] = PDS.L["STAT_PARRY"],
+        [Stats.STAT_TYPES.BLOCK] = PDS.L["STAT_BLOCK"],
+        [Stats.STAT_TYPES.ARMOR_PENETRATION] = PDS.L["STAT_ARMOR_PENETRATION"]
+    }
 end
 
 -- Returns the display name for a specific stat type

--- a/src/Utils/ConfigUI.lua
+++ b/src/Utils/ConfigUI.lua
@@ -66,7 +66,7 @@ function Utils:CreateStatColorPicker(parent, statType, y, indent)
     local colorContainer, colorPicker, resetButton, newY = ConfigUIUtils.CreateColorPicker(
         parent,
         "PeaversStat" .. statType .. "ColorPicker",
-        "Bar Color:",
+        PDS.L["CONFIG_BAR_COLOR"],
         indent,
         y,
         {r = r, g = g, b = b},
@@ -180,17 +180,17 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
     local sliderWidth = 400
 
     -- Display Settings section header
-    local header, newY = Utils:CreateSectionHeader(content, "Display Settings", baseSpacing, yPos)
+    local header, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_DISPLAY_SETTINGS"], baseSpacing, yPos)
     yPos = newY - 10
 
     -- Frame dimensions subsection
-    local dimensionsLabel, newY = Utils:CreateSubsectionLabel(content, "Frame Dimensions:", controlIndent, yPos)
+    local dimensionsLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_FRAME_DIMENSIONS"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Frame width slider
     local widthContainer, widthSlider = Utils:CreateSlider(
         content, "PeaversWidthSlider",
-        "Frame Width", 50, 400, 10,
+        PDS.L["CONFIG_FRAME_WIDTH"], 50, 400, 10,
         Config.frameWidth or 300, sliderWidth,
         function(value)
             Config.frameWidth = value
@@ -210,7 +210,7 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
     -- Background opacity slider
     local opacityContainer, opacitySlider = Utils:CreateSlider(
         content, "PeaversOpacitySlider",
-        "Background Opacity", 0, 1, 0.05,
+        PDS.L["CONFIG_BG_OPACITY"], 0, 1, 0.05,
         Config.bgAlpha or 0.5, sliderWidth,
         function(value)
             Config.bgAlpha = value
@@ -243,13 +243,13 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
     yPos = newY - 15
 
     -- Visibility options subsection
-    local visibilityLabel, newY = Utils:CreateSubsectionLabel(content, "Visibility Options:", controlIndent, yPos)
+    local visibilityLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_VISIBILITY_OPTIONS"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Show title bar checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversTitleBarCheckbox",
-        "Show Title Bar", controlIndent, yPos,
+        PDS.L["CONFIG_SHOW_TITLE_BAR"], controlIndent, yPos,
         Config.showTitleBar or true,
         function(checked)
             Config.showTitleBar = checked
@@ -264,7 +264,7 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
     -- Lock position checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversLockPositionCheckbox",
-        "Lock Frame Position", controlIndent, yPos,
+        PDS.L["CONFIG_LOCK_POSITION"], controlIndent, yPos,
         Config.lockPosition or false,
         function(checked)
             Config.lockPosition = checked
@@ -279,7 +279,7 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
     -- Hide out of combat checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversHideOutOfCombatCheckbox",
-        "Hide When Out of Combat", controlIndent, yPos,
+        PDS.L["CONFIG_HIDE_OUT_OF_COMBAT"], controlIndent, yPos,
         Config.hideOutOfCombat or false,
         function(checked)
             Config.hideOutOfCombat = checked
@@ -299,16 +299,16 @@ function ConfigUI:CreateDisplayOptions(content, yPos, baseSpacing, sectionSpacin
 
     -- Display mode dropdown
     local displayModeOptions = {
-        ["ALWAYS"] = "Always Show",
-        ["PARTY_ONLY"] = "Show in Party Only",
-        ["RAID_ONLY"] = "Show in Raid Only"
+        ["ALWAYS"] = PDS.L["CONFIG_DISPLAY_MODE_ALWAYS"],
+        ["PARTY_ONLY"] = PDS.L["CONFIG_DISPLAY_MODE_PARTY"],
+        ["RAID_ONLY"] = PDS.L["CONFIG_DISPLAY_MODE_RAID"]
     }
 
-    local currentDisplayMode = displayModeOptions[Config.displayMode] or "Always Show"
+    local currentDisplayMode = displayModeOptions[Config.displayMode] or PDS.L["CONFIG_DISPLAY_MODE_ALWAYS"]
 
     local displayModeContainer, displayModeDropdown = Utils:CreateDropdown(
         content, "PeaversDisplayModeDropdown",
-        "Display Mode", displayModeOptions,
+        PDS.L["CONFIG_DISPLAY_MODE"], displayModeOptions,
         currentDisplayMode, sliderWidth,
         function(value)
             Config.displayMode = value
@@ -333,7 +333,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
     local subControlIndent = controlIndent + 15
 
     -- Main section header
-    local header, newY = Utils:CreateSectionHeader(content, "Stat Options", baseSpacing, yPos)
+    local header, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_STAT_OPTIONS"], baseSpacing, yPos)
     yPos = newY - 10
 
     -- Function to create a show/hide checkbox for a stat
@@ -355,7 +355,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
         local _, newY = Utils:CreateCheckbox(
             content,
             "PeaversStat" .. statType .. "Checkbox",
-            "Show " .. PDS.Stats:GetName(statType),
+            PDS.L:Get("CONFIG_SHOW_STAT", PDS.Stats:GetName(statType)),
             indent, y,                           -- Pass x and y positions explicitly
             Config.showStats[statType] ~= false, -- Default to true
             onClick
@@ -364,7 +364,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
     end
 
     -- PRIMARY STATS SECTION
-    local primaryStatsHeader, newY = Utils:CreateSectionHeader(content, "Primary Stats", baseSpacing + 10, yPos, 16)
+    local primaryStatsHeader, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_PRIMARY_STATS"], baseSpacing + 10, yPos, 16)
     yPos = newY - 5
 
     -- Add explanation about primary stats
@@ -372,8 +372,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
     primaryStatsExplanation:SetPoint("TOPLEFT", baseSpacing + 15, yPos)
     primaryStatsExplanation:SetWidth(400)
     primaryStatsExplanation:SetJustifyH("LEFT")
-    primaryStatsExplanation:SetText(
-        "Primary stats are calculated as percentages, starting at 100% (base value). Buffs, talents, and equipment can increase these values beyond 100%. Higher percentages represent better performance.")
+    primaryStatsExplanation:SetText(PDS.L["CONFIG_PRIMARY_STATS_DESC"])
 
     -- Calculate the height of the explanation text
     local explanationHeight = 40
@@ -408,7 +407,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
     yPos = newY - 15
 
     -- SECONDARY STATS SECTION
-    local secondaryStatsHeader, newY = Utils:CreateSectionHeader(content, "Secondary Stats", baseSpacing + 10, yPos, 16)
+    local secondaryStatsHeader, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_SECONDARY_STATS"], baseSpacing + 10, yPos, 16)
     yPos = newY - 5
 
     -- Add explanation about secondary stats
@@ -416,8 +415,7 @@ function ConfigUI:CreateStatOptions(content, yPos, baseSpacing, sectionSpacing)
     secondaryStatsExplanation:SetPoint("TOPLEFT", baseSpacing + 15, yPos)
     secondaryStatsExplanation:SetWidth(400)
     secondaryStatsExplanation:SetJustifyH("LEFT")
-    secondaryStatsExplanation:SetText(
-        "Secondary stats enhance your character's performance: Crit, Haste, Mastery, Versatility, etc.")
+    secondaryStatsExplanation:SetText(PDS.L["CONFIG_SECONDARY_STATS_DESC"])
 
     -- Calculate the height of the explanation text
     local explanationHeight = 40
@@ -463,11 +461,11 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     local sliderWidth = 400
 
     -- Bar Appearance section header
-    local header, newY = Utils:CreateSectionHeader(content, "Bar Appearance", baseSpacing, yPos)
+    local header, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_BAR_APPEARANCE"], baseSpacing, yPos)
     yPos = newY - 10
 
     -- Bar dimensions subsection
-    local dimensionsLabel, newY = Utils:CreateSubsectionLabel(content, "Bar Dimensions:", controlIndent, yPos)
+    local dimensionsLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_BAR_DIMENSIONS"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Initialize values with defaults if they don't exist
@@ -479,7 +477,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Bar height slider
     local heightContainer, heightSlider = Utils:CreateSlider(
         content, "PeaversHeightSlider",
-        "Bar Height", 10, 40, 1,
+        PDS.L["CONFIG_BAR_HEIGHT"], 10, 40, 1,
         Config.barHeight, sliderWidth,
         function(value)
             Config.barHeight = value
@@ -496,7 +494,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Bar spacing slider
     local spacingContainer, spacingSlider = Utils:CreateSlider(
         content, "PeaversSpacingSlider",
-        "Bar Spacing", -5, 10, 1,
+        PDS.L["CONFIG_BAR_SPACING"], -5, 10, 1,
         Config.barSpacing, sliderWidth,
         function(value)
             Config.barSpacing = value
@@ -513,7 +511,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Bar background opacity slider
     local bgOpacityContainer, bgOpacitySlider = Utils:CreateSlider(
         content, "PeaversBarBgAlphaSlider",
-        "Bar Background Opacity", 0, 1, 0.05,
+        PDS.L["CONFIG_BAR_BG_OPACITY"], 0, 1, 0.05,
         Config.barBgAlpha, sliderWidth,
         function(value)
             Config.barBgAlpha = value
@@ -531,7 +529,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     yPos = newY - 15
 
     -- Bar style subsection
-    local styleLabel, newY = Utils:CreateSubsectionLabel(content, "Bar Style:", controlIndent, yPos)
+    local styleLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_BAR_STYLE"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Texture dropdown container
@@ -540,7 +538,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
 
     local textureContainer, textureDropdown = Utils:CreateDropdown(
         content, "PeaversTextureDropdown",
-        "Bar Texture", textures,
+        PDS.L["CONFIG_BAR_TEXTURE"], textures,
         currentTexture, sliderWidth,
         function(value)
             Config.barTexture = value
@@ -558,7 +556,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     yPos = newY - 15
     
     -- Additional Bar Options
-    local additionalLabel, newY = Utils:CreateSubsectionLabel(content, "Additional Bar Options:", controlIndent, yPos)
+    local additionalLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_ADDITIONAL_BAR_OPTIONS"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Initialize values with defaults if they don't exist
@@ -569,7 +567,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Show stat changes checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversShowStatChangesCheckbox",
-        "Show Stat Value Changes", controlIndent, yPos,
+        PDS.L["CONFIG_SHOW_STAT_CHANGES"], controlIndent, yPos,
         Config.showStatChanges,
         function(checked)
             Config.showStatChanges = checked
@@ -585,7 +583,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Show ratings checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversShowRatingsCheckbox",
-        "Show Rating Values", controlIndent, yPos,
+        PDS.L["CONFIG_SHOW_RATINGS"], controlIndent, yPos,
         Config.showRatings,
         function(checked)
             Config.showRatings = checked
@@ -601,7 +599,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Show overflow bars checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversShowOverflowBarsCheckbox",
-        "Show Overflow Bars", controlIndent, yPos,
+        PDS.L["CONFIG_SHOW_OVERFLOW_BARS"], controlIndent, yPos,
         Config.showOverflowBars,
         function(checked)
             Config.showOverflowBars = checked
@@ -617,7 +615,7 @@ function ConfigUI:CreateBarAppearanceOptions(content, yPos, baseSpacing, section
     -- Enable talent adjustments checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversEnableTalentAdjustmentsCheckbox",
-        "Enable Talent Adjustments (Rogue: Thief's Versatility)", controlIndent, yPos,
+        PDS.L["CONFIG_ENABLE_TALENT_ADJUSTMENTS"], controlIndent, yPos,
         Config.enableTalentAdjustments,
         function(checked)
             Config.enableTalentAdjustments = checked
@@ -641,13 +639,13 @@ function ConfigUI:CreateSpecOptions(content, yPos, baseSpacing, sectionSpacing)
     local subControlIndent = controlIndent + 15
 
     -- Specialization Settings section header
-    local header, newY = Utils:CreateSectionHeader(content, "Specialization Settings", baseSpacing, yPos)
+    local header, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_SPEC_SETTINGS"], baseSpacing, yPos)
     yPos = newY - 10
 
     -- Add "NEW" badge
     local newBadge = content:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     newBadge:SetPoint("LEFT", header, "RIGHT", 10, 0)
-    newBadge:SetText("NEW!")
+    newBadge:SetText(PDS.L["NEW_BADGE"])
     newBadge:SetTextColor(0, 1, 0)
 
     -- Create a colored glow around the NEW badge
@@ -681,7 +679,7 @@ function ConfigUI:CreateSpecOptions(content, yPos, baseSpacing, sectionSpacing)
     specExplanation:SetPoint("TOPLEFT", baseSpacing + 15, yPos)
     specExplanation:SetWidth(400)
     specExplanation:SetJustifyH("LEFT")
-    specExplanation:SetText("Control whether your addon settings should be shared between all specializations or customized per spec.")
+    specExplanation:SetText(PDS.L["CONFIG_SPEC_DESC"])
 
     -- Calculate the height of the explanation text
     local explanationHeight = 40
@@ -690,7 +688,7 @@ function ConfigUI:CreateSpecOptions(content, yPos, baseSpacing, sectionSpacing)
     -- Use shared spec settings checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversUseSharedSpecCheckbox",
-        "Use same settings for all specializations", controlIndent, yPos,
+        PDS.L["CONFIG_USE_SHARED_SPEC"], controlIndent, yPos,
         Config.useSharedSpec,
         function(checked)
             Config.useSharedSpec = checked
@@ -713,9 +711,9 @@ function ConfigUI:CreateSpecOptions(content, yPos, baseSpacing, sectionSpacing)
 
             -- Show a message to the user
             if checked then
-                PDS.Utils.Print("Settings will now be shared across all specializations")
+                PDS.Utils.Print(PDS.L["CONFIG_SPEC_SHARED_MSG"])
             else
-                PDS.Utils.Print("Each specialization will now use its own settings")
+                PDS.Utils.Print(PDS.L["CONFIG_SPEC_SEPARATE_MSG"])
             end
         end
     )
@@ -727,7 +725,7 @@ function ConfigUI:CreateSpecOptions(content, yPos, baseSpacing, sectionSpacing)
     extraInfo:SetWidth(380)
     extraInfo:SetJustifyH("LEFT")
     extraInfo:SetTextColor(0.8, 0.8, 1)
-    extraInfo:SetText("When enabled, your stat visibility, bar appearance, and other settings will be the same for all specs. When disabled, each spec can have unique settings.")
+    extraInfo:SetText(PDS.L["CONFIG_SPEC_INFO"])
 
     -- Calculate height based on the text
     local infoHeight = 50
@@ -744,15 +742,17 @@ function ConfigUI:CreateTextOptions(content, yPos, baseSpacing, sectionSpacing)
     local sliderWidth = 400
 
     -- Text Settings section header
-    local header, newY = Utils:CreateSectionHeader(content, "Text Settings", baseSpacing, yPos)
+    local header, newY = Utils:CreateSectionHeader(content, PDS.L["CONFIG_TEXT_SETTINGS"], baseSpacing, yPos)
     yPos = newY - 10
 
     -- Font selection subsection
-    local fontSelectLabel, newY = Utils:CreateSubsectionLabel(content, "Font Selection:", controlIndent, yPos)
+    local fontSelectLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_FONT_SELECTION"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Initialize values with defaults if they don't exist
-    if not Config.fontFace then Config.fontFace = "Fonts\\ARIALN.TTF" end
+    if not Config.fontFace then 
+        Config.fontFace = Config:GetDefaultFont()  -- Use locale-appropriate font
+    end
     if not Config.fontSize then Config.fontSize = 11 end
     if not Config.fontOutline then Config.fontOutline = "" end
     if not Config.fontShadow then Config.fontShadow = true end
@@ -763,7 +763,7 @@ function ConfigUI:CreateTextOptions(content, yPos, baseSpacing, sectionSpacing)
 
     local fontContainer, fontDropdown = Utils:CreateDropdown(
         content, "PeaversFontDropdown",
-        "Font", fonts,
+        PDS.L["CONFIG_FONT"], fonts,
         currentFont, sliderWidth,
         function(value)
             Config.fontFace = value
@@ -780,7 +780,7 @@ function ConfigUI:CreateTextOptions(content, yPos, baseSpacing, sectionSpacing)
     -- Font size slider
     local fontSizeContainer, fontSizeSlider = Utils:CreateSlider(
         content, "PeaversFontSizeSlider",
-        "Font Size", 6, 18, 1,
+        PDS.L["CONFIG_FONT_SIZE"], 6, 18, 1,
         Config.fontSize, sliderWidth,
         function(value)
             Config.fontSize = value
@@ -795,13 +795,13 @@ function ConfigUI:CreateTextOptions(content, yPos, baseSpacing, sectionSpacing)
     yPos = yPos - 55
 
     -- Font style options
-    local fontStyleLabel, newY = Utils:CreateSubsectionLabel(content, "Font Style:", controlIndent, yPos)
+    local fontStyleLabel, newY = Utils:CreateSubsectionLabel(content, PDS.L["CONFIG_FONT_STYLE"], controlIndent, yPos)
     yPos = newY - 8
 
     -- Font outline checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversFontOutlineCheckbox",
-        "Outlined Font", controlIndent, yPos,
+        PDS.L["CONFIG_FONT_OUTLINE"], controlIndent, yPos,
         Config.fontOutline == "OUTLINE",
         function(checked)
             Config.fontOutline = checked and "OUTLINE" or ""
@@ -817,7 +817,7 @@ function ConfigUI:CreateTextOptions(content, yPos, baseSpacing, sectionSpacing)
     -- Font shadow checkbox
     local _, newY = Utils:CreateCheckbox(
         content, "PeaversFontShadowCheckbox",
-        "Font Shadow", controlIndent, yPos,
+        PDS.L["CONFIG_FONT_SHADOW"], controlIndent, yPos,
         Config.fontShadow,
         function(checked)
             Config.fontShadow = checked


### PR DESCRIPTION
## 🌐 Add Localization Support for Fonts and UI Text
Fix issue #28 

### Overview
This PR adds comprehensive multi-language support to PeaversDynamicStats, including automatic font detection and localization for all user-facing text. The addon now fully supports **Simplified Chinese (zhCN)**, **Traditional Chinese (zhTW)**, **Korean (koKR)**, and **English (enUS)** with automatic locale detection and intelligent font management.

### 🎯 Key Features

#### 1. **Complete UI Localization**
- All user-facing text has been localized, including:
  - Stat names (Strength, Agility, Haste, Crit, etc.)
  - System messages and tooltips
- Automatic language detection based on client locale
- Fallback to English for missing translations

#### 2. **Intelligent Font Management**
- **Automatic font selection** based on client language:
  - Simplified Chinese (zhCN) → `ARKai_T.ttf`
  - Traditional Chinese (zhTW) → `bLEI00D.ttf`
  - Korean (koKR) → `2002.TTF` (not sure if this is correct, haven't run the game in Korean)
  - English/Western → `FRIZQT__.TTF`
  
- **Automatic font correction**: If a saved font is incompatible with the current locale (e.g., Western font on Chinese client), the system automatically switches to an appropriate font and saves the change
- No manual user intervention required - works out of the box

### 📁 Files Changed

#### New Files
- Localization.lua - Core localization system with translations for all supported languages

#### Modified Files
- PeaversDynamicStats.toc - Added Localization.lua to load order
- Stats.lua - Replaced hardcoded stat names with localized strings
- Utils/Config.lua - Added locale-aware font detection and auto-correction
- Utils/ConfigUI.lua - Replaced all hardcoded UI strings with localized text
- Main.lua - Added localization initialization

### 🧪 Testing

Tested on:
- ✅ Simplified Chinese client (zhCN)
- ✅ Traditional Chinese client (zhTW)
- ❌ Korean client (koKR)
- ✅ English client (enUS)